### PR TITLE
added logic to cleanup the event listener on the Navbar when it unmounts

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -27,10 +27,18 @@ const Navbar = () => {
 
     setAuthProviders();
 
-    // NOTE: close mobile menu if the viewport size is changed
-    window.addEventListener('resize', () => {
+    // Function to handle resize
+    const handleResize = () => {
       setIsMobileMenuOpen(false);
-    });
+    };
+
+    // NOTE: close mobile menu if the viewport size is changed
+    window.addEventListener('resize', handleResize);
+
+    // Cleanup event listener on unmount
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
Hello! I was wondering if this `cleanup code` is necessary for when the Navbar unmounts:

![image](https://github.com/user-attachments/assets/a22e563a-6f00-43b3-b72f-2b95bd5a18e6)

On a side note, I really love this course and enjoy how in-depth your explanations are! This course has changed me from disliking web development, to really enjoying what it can offer.
